### PR TITLE
Fix invalid keyword in Offer filter by_name.

### DIFF
--- a/paymill/models/offer.py
+++ b/paymill/models/offer.py
@@ -83,7 +83,7 @@ class Offer(JsonObject):
             :param str name: the payment id to filter by
             :return: Filter object
             """
-            return Filter('payment', values=(name,), operator=Filter.OPERATOR['EQUAL'])
+            return Filter('name', values=(name,), operator=Filter.OPERATOR['EQUAL'])
 
         @classmethod
         def by_trial_period_days(cls, trial_period_days):


### PR DESCRIPTION
Hi,

The keyword used in the filter *by_name* of the Offer model seems wrong.
Currently in master (and pypi package) the *payment* keyword is in use.

While using this filter, i get the following error from Paymill:

```python
send: 'GET /v2.1/offers?payment=discovery HTTP/1.1\r\nHost: api.paymill.com\r\nConnection: keep-alive\r\nAuthorization: Basic Token_redacted___\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nUser-Agent: python-requests/2.4.3 CPython/2.7.6 Linux/3.16.0-28-generic\r\n\r\n'
reply: 'HTTP/1.1 400 Bad Request\r\n'
header: Server: nginx
header: Date: Tue, 31 Mar 2015 15:28:39 GMT
header: Content-Type: application/json
header: Transfer-Encoding: chunked
header: Connection: keep-alive
Traceback (most recent call last):
  File "<console>", line 4, in <module>
  File "/home/lao/dev/playlist4me/backend/users/models.py", line 357, in create_paymill_subscription
    offer = offers.list(filtr=paymill.models.offer.Offer.Filter.by_name(self.offer))
  File "/home/lao/Envs/p4m/local/lib/python2.7/site-packages/paymill/services/paymill_service.py", line 72, in list
    return self._list(**params)
  File "/home/lao/Envs/p4m/local/lib/python2.7/site-packages/paymill/services/paymill_service.py", line 52, in _list
    return self.http_client('GET', dict(**kwargs), self.endpoint_path(), PaymillList)
  File "/home/lao/Envs/p4m/local/lib/python2.7/site-packages/paymill/utils/http_client.py", line 33, in __call__
    return self.operations[request_type](params, url, return_type)
  File "/home/lao/Envs/p4m/local/lib/python2.7/site-packages/paymill/utils/http_client.py", line 56, in get
    hooks=dict(response=self._request_callback)).json(), return_type)
  File "/home/lao/Envs/p4m/local/lib/python2.7/site-packages/paymill/utils/http_client.py", line 70, in _check_reponse
    raise PMError(json_data, self.response.status_code)
PMError: "{u'exception': u'Api_Exception_InvalidParameter', u'error': u'payment'}400"
```

By simply switching to the *name* keyword, the filter works fine.

Thanks for considering this pull request.