### PR TITLE
Fix creation of a webhook with multiple events.

### DIFF
--- a/paymill/services/webhook_service.py
+++ b/paymill/services/webhook_service.py
@@ -34,10 +34,9 @@ class WebhookService(PaymillService):
 
     @classmethod
     def _event_types_to_dict(cls, event_types):
-        event_types_dict = {}
-        for e in event_types:
-            event_types_dict.update(dict({'event_types[]': e}))
-        return event_types_dict
+        return {
+            'event_types[]' : event_types,
+        }
 
     def detail(self, obj):
         """Returns/refreshes the remote Webhook representation with that obj.id


### PR DESCRIPTION
When event_types contains multiple events strings, only the last one is sent to the paymill server.
The generated dictionary in `WebHookService._event_types_to_dict` only contains the last item from the loop because it always uses the same key (`event_types[]`)

Urllib is smart enough to directly convert a Python list to multiple HTTP parameters in the request body. 

I tested it while creating a Mail hook with 8 event types.